### PR TITLE
Fix typo and change column used in Listing 13-8.

### DIFF
--- a/Chapter_13/Chapter_13.sql
+++ b/Chapter_13/Chapter_13.sql
@@ -107,10 +107,10 @@ VALUES (2, 'Janet', 'King'),
 
 SELECT first_name, last_name
 FROM employees
-WHERE emp_id IN (
+WHERE id IN (
     SELECT id
     FROM retirees)
-ORDER BY emp_id;
+ORDER BY id;
     
 -- Listing 13-9: Using a correlated subquery with WHERE EXISTS
 

--- a/Try_It_Yourself/Try_It_Yourself.sql
+++ b/Try_It_Yourself/Try_It_Yourself.sql
@@ -458,7 +458,7 @@ CREATE TABLE songs (
 -- We could consider the catalog_code. We would have to answer yes to
 -- these questions:
 -- 1. Is it going to be unique across all albums released by all companies?
--- 2. Will an album always have a catelog code?
+-- 2. Will an album always have a catalog code?
 
 
 -- 3. To speed up queries, which columns are good candidates for indexes?


### PR DESCRIPTION
* [Change 'emp_id' to 'id' for Listing 13-8.](https://github.com/anthonydb/practical-sql-2/commit/b95b96e47f1f6988d45c850ac213ef9dc9daf0da)
* [Change 'catelog' to 'catalog.'](https://github.com/anthonydb/practical-sql-2/commit/5a1e1fecff07279fa78c584f9133811da84ffa09)